### PR TITLE
feat: add support for custom/historical order dates in POS screens

### DIFF
--- a/captain/src/views/captain/order/UnifiedOrder.js
+++ b/captain/src/views/captain/order/UnifiedOrder.js
@@ -60,6 +60,11 @@ const DEFAULT_PAYMENT_DATA = {
   total: 0, paidAmount: '', waveoffAmount: 0, paymentType: 'Cash',
 };
 
+const getLocalDateTimeString = (date = new Date()) => {
+  const tzoffset = date.getTimezoneOffset() * 60000;
+  return new Date(date.getTime() - tzoffset).toISOString().slice(0, 16);
+};
+
 // ── Component ──────────────────────────────────────────────────────────────────
 const UnifiedOrder = () => {
   const history = useHistory();
@@ -79,6 +84,7 @@ const UnifiedOrder = () => {
 
   // ── Order Type ────────────────────────────────────────────────────────────
   const [orderType, setOrderType] = useState(defaultType);
+  const [orderDate, setOrderDate] = useState(getLocalDateTimeString());
   const isEditMode = mode === 'edit';
 
   const title = `${isEditMode ? 'Edit' : 'New'} ${orderType} Order`;
@@ -210,6 +216,9 @@ const UnifiedOrder = () => {
       setTokenNumber(order.token || null);
       setCustomerInfo(custInfo);
       setOrderNo(order.order_no || '');
+      if (order.order_date) {
+        setOrderDate(getLocalDateTimeString(new Date(order.order_date)));
+      }
       initialStateRef.current = {
         orderItems: JSON.parse(JSON.stringify(items)),
         customerInfo: JSON.parse(JSON.stringify(custInfo)),
@@ -375,6 +384,7 @@ const UnifiedOrder = () => {
   const buildPayload = (status, completeAll = false) => {
     const orderData = {
       order_type: orderType,
+      order_date: orderDate ? new Date(orderDate) : new Date(),
       order_items: orderItems.map((item) => ({
         dish_name: item.dish_name, quantity: item.quantity, dish_price: item.dish_price,
         special_notes: item.special_notes || '',
@@ -632,8 +642,23 @@ const UnifiedOrder = () => {
               <option key={t} value={t}>{t}</option>
             ))}
           </Form.Select>
-          <div className="text-muted small fw-semibold" style={{ flexShrink: 0 }}>
-            {new Date().toLocaleDateString('en-IN')}
+          <div className="d-flex align-items-center gap-1" style={{ flexShrink: 0 }}>
+            <span className="text-muted small fw-semibold">Date:</span>
+            <Form.Control
+              type="datetime-local"
+              size="sm"
+              value={orderDate}
+              onChange={(e) => setOrderDate(e.target.value)}
+              style={{
+                borderRadius: '50px',
+                borderColor: 'rgba(35,179,244,0.35)',
+                color: '#23b3f4',
+                fontWeight: 700,
+                fontSize: '12px',
+                padding: '0.15rem 0.5rem',
+                maxWidth: '185px',
+              }}
+            />
           </div>
         </div>
 

--- a/cashier/src/views/manager/order/UnifiedOrder.js
+++ b/cashier/src/views/manager/order/UnifiedOrder.js
@@ -72,6 +72,11 @@ const DEFAULT_PAYMENT_DATA = {
   paymentType: 'Cash',
 };
 
+const getLocalDateTimeString = (date = new Date()) => {
+  const tzoffset = date.getTimezoneOffset() * 60000;
+  return new Date(date.getTime() - tzoffset).toISOString().slice(0, 16);
+};
+
 // ── Component ──────────────────────────────────────────────────────────────────
 const UnifiedOrder = () => {
   const history = useHistory();
@@ -92,6 +97,7 @@ const UnifiedOrder = () => {
 
   // ── Order Type ────────────────────────────────────────────────────────────
   const [orderType, setOrderType] = useState(defaultType);
+  const [orderDate, setOrderDate] = useState(getLocalDateTimeString());
   const isEditMode = mode === 'edit';
 
   const title = `${isEditMode ? 'Edit' : 'New'} ${orderType} Order`;
@@ -228,6 +234,9 @@ const UnifiedOrder = () => {
       setTokenNumber(order.token || null);
       setCustomerInfo(custInfo);
       setOrderNo(order.order_no || '');
+      if (order.order_date) {
+        setOrderDate(getLocalDateTimeString(new Date(order.order_date)));
+      }
       initialStateRef.current = {
         orderItems: JSON.parse(JSON.stringify(items)),
         customerInfo: JSON.parse(JSON.stringify(custInfo)),
@@ -432,6 +441,7 @@ const UnifiedOrder = () => {
   const buildPayload = (status, completeAll = false) => {
     const orderData = {
       order_type: orderType,
+      order_date: orderDate ? new Date(orderDate) : new Date(),
       order_items: orderItems.map((item) => {
         let itemStatus = item.status || 'Pending';
         if (completeAll) {
@@ -811,8 +821,23 @@ const UnifiedOrder = () => {
               </option>
             ))}
           </Form.Select>
-          <div className="text-muted small fw-semibold" style={{ flexShrink: 0 }}>
-            {new Date().toLocaleDateString('en-IN')}
+          <div className="d-flex align-items-center gap-1" style={{ flexShrink: 0 }}>
+            <span className="text-muted small fw-semibold">Date:</span>
+            <Form.Control
+              type="datetime-local"
+              size="sm"
+              value={orderDate}
+              onChange={(e) => setOrderDate(e.target.value)}
+              style={{
+                borderRadius: '50px',
+                borderColor: 'rgba(35,179,244,0.35)',
+                color: '#23b3f4',
+                fontWeight: 700,
+                fontSize: '12px',
+                padding: '0.15rem 0.5rem',
+                maxWidth: '185px',
+              }}
+            />
           </div>
         </div>
 

--- a/cashier/src/views/qsr/order/UnifiedOrder.js
+++ b/cashier/src/views/qsr/order/UnifiedOrder.js
@@ -72,6 +72,11 @@ const DEFAULT_PAYMENT_DATA = {
   paymentType: 'Cash',
 };
 
+const getLocalDateTimeString = (date = new Date()) => {
+  const tzoffset = date.getTimezoneOffset() * 60000;
+  return new Date(date.getTime() - tzoffset).toISOString().slice(0, 16);
+};
+
 // ── Component ──────────────────────────────────────────────────────────────────
 const UnifiedOrder = () => {
   const history = useHistory();
@@ -93,6 +98,7 @@ const UnifiedOrder = () => {
 
   // ── Order Type ────────────────────────────────────────────────────────────
   const [orderType, setOrderType] = useState(defaultType);
+  const [orderDate, setOrderDate] = useState(getLocalDateTimeString());
   const isEditMode = mode === 'edit';
 
   const title = `${isEditMode ? 'Edit' : 'New'} ${orderType} Order`;
@@ -229,6 +235,9 @@ const UnifiedOrder = () => {
       setTokenNumber(order.token || null);
       setCustomerInfo(custInfo);
       setOrderNo(order.order_no || '');
+      if (order.order_date) {
+        setOrderDate(getLocalDateTimeString(new Date(order.order_date)));
+      }
       initialStateRef.current = {
         orderItems: JSON.parse(JSON.stringify(items)),
         customerInfo: JSON.parse(JSON.stringify(custInfo)),
@@ -432,6 +441,7 @@ const UnifiedOrder = () => {
   const buildPayload = (status, completeAll = false) => {
     const orderData = {
       order_type: orderType,
+      order_date: orderDate ? new Date(orderDate) : new Date(),
       order_items: orderItems.map((item) => {
         let itemStatus = item.status || 'Pending';
         if (completeAll) {
@@ -807,8 +817,23 @@ const UnifiedOrder = () => {
               </option>
             ))}
           </Form.Select>
-          <div className="text-muted small fw-semibold" style={{ flexShrink: 0 }}>
-            {new Date().toLocaleDateString('en-IN')}
+          <div className="d-flex align-items-center gap-1" style={{ flexShrink: 0 }}>
+            <span className="text-muted small fw-semibold">Date:</span>
+            <Form.Control
+              type="datetime-local"
+              size="sm"
+              value={orderDate}
+              onChange={(e) => setOrderDate(e.target.value)}
+              style={{
+                borderRadius: '50px',
+                borderColor: 'rgba(35,179,244,0.35)',
+                color: '#23b3f4',
+                fontWeight: 700,
+                fontSize: '12px',
+                padding: '0.15rem 0.5rem',
+                maxWidth: '185px',
+              }}
+            />
           </div>
         </div>
 

--- a/manager/src/views/manager/order/UnifiedOrder.js
+++ b/manager/src/views/manager/order/UnifiedOrder.js
@@ -72,6 +72,11 @@ const DEFAULT_PAYMENT_DATA = {
   paymentType: 'Cash',
 };
 
+const getLocalDateTimeString = (date = new Date()) => {
+  const tzoffset = date.getTimezoneOffset() * 60000;
+  return new Date(date.getTime() - tzoffset).toISOString().slice(0, 16);
+};
+
 // ── Component ──────────────────────────────────────────────────────────────────
 const UnifiedOrder = () => {
   const history = useHistory();
@@ -92,6 +97,7 @@ const UnifiedOrder = () => {
 
   // ── Order Type ────────────────────────────────────────────────────────────
   const [orderType, setOrderType] = useState(defaultType);
+  const [orderDate, setOrderDate] = useState(getLocalDateTimeString());
   const isEditMode = mode === 'edit';
 
   const title = `${isEditMode ? 'Edit' : 'New'} ${orderType} Order`;
@@ -232,6 +238,9 @@ const UnifiedOrder = () => {
       setTokenNumber(order.token || null);
       setCustomerInfo(custInfo);
       setOrderNo(order.order_no || '');
+      if (order.order_date) {
+        setOrderDate(getLocalDateTimeString(new Date(order.order_date)));
+      }
       initialStateRef.current = {
         orderItems: JSON.parse(JSON.stringify(items)),
         customerInfo: JSON.parse(JSON.stringify(custInfo)),
@@ -476,6 +485,7 @@ const UnifiedOrder = () => {
 
     const orderData = {
       order_type: orderType,
+      order_date: orderDate ? new Date(orderDate) : new Date(),
       order_items: orderItems.map((item) => {
         let itemStatus = item.status || 'Pending';
         if (completeAll) {
@@ -859,8 +869,23 @@ const UnifiedOrder = () => {
               </option>
             ))}
           </Form.Select>
-          <div className="text-muted small fw-semibold" style={{ flexShrink: 0 }}>
-            {new Date().toLocaleDateString('en-IN')}
+          <div className="d-flex align-items-center gap-1" style={{ flexShrink: 0 }}>
+            <span className="text-muted small fw-semibold">Date:</span>
+            <Form.Control
+              type="datetime-local"
+              size="sm"
+              value={orderDate}
+              onChange={(e) => setOrderDate(e.target.value)}
+              style={{
+                borderRadius: '50px',
+                borderColor: 'rgba(35,179,244,0.35)',
+                color: '#23b3f4',
+                fontWeight: 700,
+                fontSize: '12px',
+                padding: '0.15rem 0.5rem',
+                maxWidth: '185px',
+              }}
+            />
           </div>
         </div>
 

--- a/manager/src/views/qsr/order/UnifiedOrder.js
+++ b/manager/src/views/qsr/order/UnifiedOrder.js
@@ -72,6 +72,11 @@ const DEFAULT_PAYMENT_DATA = {
   paymentType: 'Cash',
 };
 
+const getLocalDateTimeString = (date = new Date()) => {
+  const tzoffset = date.getTimezoneOffset() * 60000;
+  return new Date(date.getTime() - tzoffset).toISOString().slice(0, 16);
+};
+
 // ── Component ──────────────────────────────────────────────────────────────────
 const UnifiedOrder = () => {
   const history = useHistory();
@@ -93,6 +98,7 @@ const UnifiedOrder = () => {
 
   // ── Order Type ────────────────────────────────────────────────────────────
   const [orderType, setOrderType] = useState(defaultType);
+  const [orderDate, setOrderDate] = useState(getLocalDateTimeString());
   const isEditMode = mode === 'edit';
 
   const title = `${isEditMode ? 'Edit' : 'New'} ${orderType} Order`;
@@ -229,6 +235,9 @@ const UnifiedOrder = () => {
       setTokenNumber(order.token || null);
       setCustomerInfo(custInfo);
       setOrderNo(order.order_no || '');
+      if (order.order_date) {
+        setOrderDate(getLocalDateTimeString(new Date(order.order_date)));
+      }
       initialStateRef.current = {
         orderItems: JSON.parse(JSON.stringify(items)),
         customerInfo: JSON.parse(JSON.stringify(custInfo)),
@@ -432,6 +441,7 @@ const UnifiedOrder = () => {
   const buildPayload = (status, completeAll = false) => {
     const orderData = {
       order_type: orderType,
+      order_date: orderDate ? new Date(orderDate) : new Date(),
       order_items: orderItems.map((item) => {
         let itemStatus = item.status || 'Pending';
         if (completeAll) {
@@ -817,8 +827,23 @@ const UnifiedOrder = () => {
               </option>
             ))}
           </Form.Select>
-          <div className="text-muted small fw-semibold" style={{ flexShrink: 0 }}>
-            {new Date().toLocaleDateString('en-IN')}
+          <div className="d-flex align-items-center gap-1" style={{ flexShrink: 0 }}>
+            <span className="text-muted small fw-semibold">Date:</span>
+            <Form.Control
+              type="datetime-local"
+              size="sm"
+              value={orderDate}
+              onChange={(e) => setOrderDate(e.target.value)}
+              style={{
+                borderRadius: '50px',
+                borderColor: 'rgba(35,179,244,0.35)',
+                color: '#23b3f4',
+                fontWeight: 700,
+                fontSize: '12px',
+                padding: '0.15rem 0.5rem',
+                maxWidth: '185px',
+              }}
+            />
           </div>
         </div>
 

--- a/qsr/src/views/qsr/order/UnifiedOrder.js
+++ b/qsr/src/views/qsr/order/UnifiedOrder.js
@@ -72,6 +72,11 @@ const DEFAULT_PAYMENT_DATA = {
   paymentType: 'Cash',
 };
 
+const getLocalDateTimeString = (date = new Date()) => {
+  const tzoffset = date.getTimezoneOffset() * 60000;
+  return new Date(date.getTime() - tzoffset).toISOString().slice(0, 16);
+};
+
 // ── Component ──────────────────────────────────────────────────────────────────
 const UnifiedOrder = () => {
   const history = useHistory();
@@ -91,6 +96,7 @@ const UnifiedOrder = () => {
 
   // ── Order Type ────────────────────────────────────────────────────────────
   const [orderType, setOrderType] = useState(defaultType);
+  const [orderDate, setOrderDate] = useState(getLocalDateTimeString());
   const isEditMode = mode === 'edit';
 
   const title = `${isEditMode ? 'Edit' : 'New'} ${orderType} Order`;
@@ -227,6 +233,9 @@ const UnifiedOrder = () => {
       setTokenNumber(order.token || null);
       setCustomerInfo(custInfo);
       setOrderNo(order.order_no || '');
+      if (order.order_date) {
+        setOrderDate(getLocalDateTimeString(new Date(order.order_date)));
+      }
       initialStateRef.current = {
         orderItems: JSON.parse(JSON.stringify(items)),
         customerInfo: JSON.parse(JSON.stringify(custInfo)),
@@ -430,6 +439,7 @@ const UnifiedOrder = () => {
   const buildPayload = (status, completeAll = false) => {
     const orderData = {
       order_type: orderType,
+      order_date: orderDate ? new Date(orderDate) : new Date(),
       order_items: orderItems.map((item) => {
         let itemStatus = item.status || 'Pending';
         if (completeAll) {
@@ -815,8 +825,23 @@ const UnifiedOrder = () => {
               </option>
             ))}
           </Form.Select>
-          <div className="text-muted small fw-semibold" style={{ flexShrink: 0 }}>
-            {new Date().toLocaleDateString('en-IN')}
+          <div className="d-flex align-items-center gap-1" style={{ flexShrink: 0 }}>
+            <span className="text-muted small fw-semibold">Date:</span>
+            <Form.Control
+              type="datetime-local"
+              size="sm"
+              value={orderDate}
+              onChange={(e) => setOrderDate(e.target.value)}
+              style={{
+                borderRadius: '50px',
+                borderColor: 'rgba(35,179,244,0.35)',
+                color: '#23b3f4',
+                fontWeight: 700,
+                fontSize: '12px',
+                padding: '0.15rem 0.5rem',
+                maxWidth: '185px',
+              }}
+            />
           </div>
         </div>
 

--- a/restaurant-3d/src/pages/Cart.jsx
+++ b/restaurant-3d/src/pages/Cart.jsx
@@ -150,7 +150,7 @@ export default function Cart() {
             <div data-reveal="right" data-delay="0.2" className="glass rounded-4 p-4 position-sticky" style={{ top: '8rem' }}>
               <h5 className="fw-semibold text-white mb-4">Summary</h5>
 
-              <div className="d-flex flex-column gap-3 pb-3 mb-3" style={{ borderBottom: '1px solid rgba(255,255,255,0.1)' }}>
+              <div className="d-flex flex-column gap-3 pb-3 mb-3">
                 <div className="d-flex justify-content-between small">
                   <span className="text-white-60">Subtotal</span>
                   <span className="text-white">₹{subtotal.toFixed(2)}</span>
@@ -160,7 +160,7 @@ export default function Cart() {
                   <span className="text-white">{delivery === 0 ? 'Free' : `₹${delivery.toFixed(2)}`}</span>
                 </div>
                 <div className="d-flex justify-content-between small">
-                  <span className="text-white-60">Tax (${totalTaxRatePercent}%)</span>
+                  <span className="text-white-60">Tax ({totalTaxRatePercent}%)</span>
                   <span className="text-white">₹{tax.toFixed(2)}</span>
                 </div>
               </div>

--- a/street-food/src/views/qsr/order/UnifiedOrder.js
+++ b/street-food/src/views/qsr/order/UnifiedOrder.js
@@ -72,6 +72,11 @@ const DEFAULT_PAYMENT_DATA = {
   paymentType: 'Cash',
 };
 
+const getLocalDateTimeString = (date = new Date()) => {
+  const tzoffset = date.getTimezoneOffset() * 60000;
+  return new Date(date.getTime() - tzoffset).toISOString().slice(0, 16);
+};
+
 // ── Component ──────────────────────────────────────────────────────────────────
 const UnifiedOrder = () => {
   const history = useHistory();
@@ -91,6 +96,7 @@ const UnifiedOrder = () => {
 
   // ── Order Type ────────────────────────────────────────────────────────────
   const [orderType, setOrderType] = useState(defaultType);
+  const [orderDate, setOrderDate] = useState(getLocalDateTimeString());
   const isEditMode = mode === 'edit';
 
   const title = `${isEditMode ? 'Edit' : 'New'} ${orderType} Order`;
@@ -227,6 +233,9 @@ const UnifiedOrder = () => {
       setTokenNumber(order.token || null);
       setCustomerInfo(custInfo);
       setOrderNo(order.order_no || '');
+      if (order.order_date) {
+        setOrderDate(getLocalDateTimeString(new Date(order.order_date)));
+      }
       initialStateRef.current = {
         orderItems: JSON.parse(JSON.stringify(items)),
         customerInfo: JSON.parse(JSON.stringify(custInfo)),
@@ -430,6 +439,7 @@ const UnifiedOrder = () => {
   const buildPayload = (status, completeAll = false) => {
     const orderData = {
       order_type: orderType,
+      order_date: orderDate ? new Date(orderDate) : new Date(),
       order_items: orderItems.map((item) => {
         let itemStatus = item.status || 'Pending';
         if (completeAll) {
@@ -814,8 +824,23 @@ const UnifiedOrder = () => {
               </option>
             ))}
           </Form.Select>
-          <div className="text-muted small fw-semibold" style={{ flexShrink: 0 }}>
-            {new Date().toLocaleDateString('en-IN')}
+          <div className="d-flex align-items-center gap-1" style={{ flexShrink: 0 }}>
+            <span className="text-muted small fw-semibold">Date:</span>
+            <Form.Control
+              type="datetime-local"
+              size="sm"
+              value={orderDate}
+              onChange={(e) => setOrderDate(e.target.value)}
+              style={{
+                borderRadius: '50px',
+                borderColor: 'rgba(35,179,244,0.35)',
+                color: '#23b3f4',
+                fontWeight: 700,
+                fontSize: '12px',
+                padding: '0.15rem 0.5rem',
+                maxWidth: '185px',
+              }}
+            />
           </div>
         </div>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Order screens now let you view and edit the order date and time before saving or printing.
  * Existing orders keep their saved date/time when reopened for editing.

* **Bug Fixes**
  * Corrected the cart summary tax label formatting.
  * Removed an extra border style in the cart totals area for a cleaner layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->